### PR TITLE
Fix memory leak when deleting process

### DIFF
--- a/ga.cpp
+++ b/ga.cpp
@@ -37,16 +37,17 @@ while (actual != nullptr && actual->proceso->id != id) {
 anterior = actual;
 actual = actual->siguiente;
 }
-if (actual != nullptr) {
-if (anterior == nullptr)
-cabeza = actual->siguiente;
-else
-anterior->siguiente = actual->siguiente;
-delete actual;
-cout << "Proceso eliminado.\n";
-} else {
-cout << "Proceso no encontrado.\n";
-}
+        if (actual != nullptr) {
+            if (anterior == nullptr)
+                cabeza = actual->siguiente;
+            else
+                anterior->siguiente = actual->siguiente;
+            delete actual->proceso; // liberar memoria del proceso
+            delete actual;
+            cout << "Proceso eliminado.\n";
+        } else {
+            cout << "Proceso no encontrado.\n";
+        }
 }
 Proceso* buscar(int id) {
 Nodo* actual = cabeza;


### PR DESCRIPTION
## Summary
- fix a memory leak in `ListaProcesos::eliminar` by deleting the process object before deleting the node

## Testing
- `g++ ga.cpp -o ga.exe`
- `./ga.exe <<EOF
0
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6847d2759f38832191949f93102b522f